### PR TITLE
AWS-LC compatibility changes to upstream for OpenSSH

### DIFF
--- a/.github/configs
+++ b/.github/configs
@@ -161,6 +161,9 @@ case "$config" in
 	CONFIGFLAGS="--disable-pkcs11"
 	LIBCRYPTOFLAGS="--with-ssl-dir=/opt/boringssl --with-rpath=-Wl,-rpath,"
 	;;
+	aws-lc)
+	LIBCRYPTOFLAGS="--with-ssl-dir=/opt/aws-lc --with-rpath=-Wl,-rpath,"
+	;;
     libressl-*)
 	LIBCRYPTOFLAGS="--with-ssl-dir=/opt/libressl --with-rpath=-Wl,-rpath,"
 	;;

--- a/.github/setup_ci.sh
+++ b/.github/setup_ci.sh
@@ -142,6 +142,10 @@ for TARGET in $TARGETS; do
         INSTALL_BORINGSSL=1
         PACKAGES="${PACKAGES} cmake ninja-build"
        ;;
+    aws-lc)
+        INSTALL_AWSLC=1
+        PACKAGES="${PACKAGES} cmake ninja-build golang"
+        ;;
     putty-*)
 	INSTALL_PUTTY=$(echo "${TARGET}" | cut -f2 -d-)
 	PACKAGES="${PACKAGES} cmake"
@@ -238,6 +242,15 @@ if [ ! -z "${INSTALL_BORINGSSL}" ]; then
      mkdir -p /opt/boringssl/lib &&
      cp ${HOME}/boringssl/build/crypto/libcrypto.a /opt/boringssl/lib &&
      cp -r ${HOME}/boringssl/include /opt/boringssl)
+fi
+
+if [ ! -z "${INSTALL_AWSLC}" ]; then
+    (cd ${HOME} && git clone --depth 1 --branch v1.42.0 https://github.com/aws/aws-lc.git &&
+     cd ${HOME}/aws-lc && mkdir build && cd build &&
+     cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. && ninja &&
+     mkdir -p /opt/aws-lc/lib &&
+     cp ${HOME}/aws-lc/build/crypto/libcrypto.a /opt/aws-lc/lib &&
+     cp -r ${HOME}/aws-lc/include /opt/aws-lc)
 fi
 
 if [ ! -z "${INSTALL_ZLIB}" ]; then

--- a/.github/setup_ci.sh
+++ b/.github/setup_ci.sh
@@ -144,7 +144,7 @@ for TARGET in $TARGETS; do
        ;;
     aws-lc)
         INSTALL_AWSLC=1
-        PACKAGES="${PACKAGES} cmake ninja-build golang"
+        PACKAGES="${PACKAGES} cmake ninja-build"
         ;;
     putty-*)
 	INSTALL_PUTTY=$(echo "${TARGET}" | cut -f2 -d-)
@@ -247,7 +247,7 @@ fi
 if [ ! -z "${INSTALL_AWSLC}" ]; then
     (cd ${HOME} && git clone --depth 1 --branch v1.42.0 https://github.com/aws/aws-lc.git &&
      cd ${HOME}/aws-lc && mkdir build && cd build &&
-     cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. && ninja &&
+     cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. && ninja &&
      mkdir -p /opt/aws-lc/lib &&
      cp ${HOME}/aws-lc/build/crypto/libcrypto.a /opt/aws-lc/lib &&
      cp -r ${HOME}/aws-lc/include /opt/aws-lc)

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -55,6 +55,7 @@ jobs:
           - { target: ubuntu-20.04, config: tcmalloc }
           - { target: ubuntu-20.04, config: musl }
           - { target: ubuntu-latest, config: boringssl }
+          - { target: ubuntu-latest, config: aws-lc }
           - { target: ubuntu-latest, config: libressl-master }
           - { target: ubuntu-latest, config: libressl-3.2.6 }
           - { target: ubuntu-latest, config: libressl-3.3.6 }

--- a/configure.ac
+++ b/configure.ac
@@ -3276,6 +3276,12 @@ fi
 # PKCS11/U2F depend on OpenSSL and dlopen().
 enable_pkcs11=yes
 enable_sk=yes
+
+AC_CHECK_DECL([OPENSSL_IS_AWSLC],
+	[enable_pkcs11="disabled; PKCS#11 not supported with AWS-LC"],
+	[],
+	[#include <openssl/base.h>]
+)
 if test "x$openssl" != "xyes" ; then
 	enable_pkcs11="disabled; missing libcrypto"
 fi

--- a/openbsd-compat/openssl-compat.h
+++ b/openbsd-compat/openssl-compat.h
@@ -57,7 +57,7 @@ void ssh_libcrypto_init(void);
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 /*
- * BoringSSL (rightly) got rid of the BN_FLG_CONSTTIME flag, along with
+ * BoringSSL and AWS-LC (rightly) got rid of the BN_FLG_CONSTTIME flag, along with
  * the entire BN_set_flags() interface.
  * https://boringssl.googlesource.com/boringssl/+/0a211dfe9
  */

--- a/openbsd-compat/openssl-compat.h
+++ b/openbsd-compat/openssl-compat.h
@@ -55,7 +55,7 @@ void ssh_libcrypto_init(void);
 # endif
 #endif
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 /*
  * BoringSSL (rightly) got rid of the BN_FLG_CONSTTIME flag, along with
  * the entire BN_set_flags() interface.


### PR DESCRIPTION
PKCS11 is disabled in the configure script. OPENSSL_IS_AWSLC is used to tag onto an existing BORINGSSL ifdef for BN_FLG_CONSTTIME. With these changes, no additional flags or arguments will be required when building OpenSSH mainline with AWS-LC. 